### PR TITLE
Feat: Keep the structure of the sources folder for doc structure #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,15 @@ export default config;
 
 Here are all the configuration parameters that are currently available, but as said above, all of them are entirely optional:
 
-| Parameter | Description | Default value |
-| -------- | -------- | -------- |
-| `runOnCompile`     | True if the plugin should generate the documentation on every compilation | `true`     |
-| `include` | List of all the contract / interface / library names to include in the documentation generation. An empty array will generate documentation for everything | `[]` |
-| `exclude` | List of all the contract / interface / library names to exclude from the documentation generation | `[]` |
-| `outputDir` | Output directory of the documentation | `docs` |
-| `templatePath` | Path to the documentation template | `./template.sqrl`|
-| `testMode` | Test mode generating additional JSON files used for debugging | `false` |
+| Parameter           | Description                                                                                                                                                | Default value     |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| `runOnCompile`      | True if the plugin should generate the documentation on every compilation                                                                                  | `true`            |
+| `include`           | List of all the contract / interface / library names to include in the documentation generation. An empty array will generate documentation for everything | `[]`              |
+| `exclude`           | List of all the contract / interface / library names to exclude from the documentation generation                                                          | `[]`              |
+| `outputDir`         | Output directory of the documentation                                                                                                                      | `docs`            |
+| `templatePath`      | Path to the documentation template                                                                                                                         | `./template.sqrl` |
+| `testMode`          | Test mode generating additional JSON files used for debugging                                                                                              | `false`           |
+| `keepFileStructure` | True if you want to preserve your contracts file structure                                                                                                 | `true`            |
 
 ## 💅 Customize
 

--- a/src/dodocTypes.ts
+++ b/src/dodocTypes.ts
@@ -129,6 +129,7 @@ export interface Error {
 }
 
 export interface Doc {
+  path?: string;
   name?: string;
   title?: string;
   notice?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     testMode: userConfig.dodoc?.testMode || false,
     outputDir: userConfig.dodoc?.outputDir || './docs',
     templatePath: userConfig.dodoc?.templatePath || path.join(__dirname, './template.sqrl'),
-    keepFileStructure: userConfig.dodoc?.keepFileStructure || true,
+    keepFileStructure: userConfig.dodoc?.keepFileStructure ?? true,
   };
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,6 @@ task(TASK_COMPILE, async (args, hre, runSuper) => {
   const sourcesPath = hre.config.paths.sources.substr(process.cwd().length + 1); // trick to get relative path to files, and trim the first /
   for (const qualifiedName of qualifiedNames) {
     const [source, name] = qualifiedName.split(':');
-
     // Checks if the documentation has to be generated for this contract
     if ((config.include.length === 0 || config.include.includes(name)) && !config.exclude.includes(name)) {
       const buildInfo = await hre.artifacts.getBuildInfo(qualifiedName);
@@ -70,7 +69,7 @@ task(TASK_COMPILE, async (args, hre, runSuper) => {
         console.log(JSON.stringify(info.devdoc, null, 4));
       }
 
-      const doc = { ...decodeAbi(info.abi), path: source.substr(sourcesPath.length).split('/').slice(0, -1).join('/') }; // remove filename
+      const doc = { ...decodeAbi(info.abi), path: source.substr(sourcesPath.length).split('/').slice(0, -1).join('/') }; // get file path without filename
 
       // Fetches info from userdoc
       for (const errorSig in info.userdoc?.errors) {
@@ -153,7 +152,6 @@ task(TASK_COMPILE, async (args, hre, runSuper) => {
       if (info.userdoc?.notice) doc.notice = info.userdoc.notice;
       if (info.devdoc?.details) doc.details = info.devdoc.details;
       if (info.devdoc?.author) doc.author = info.devdoc.author;
-
       doc.name = name;
       docs.push(doc);
     }
@@ -173,8 +171,8 @@ task(TASK_COMPILE, async (args, hre, runSuper) => {
     const result = Sqrl.render(template, docs[i]);
     let docfileName = `${docs[i].name}.md`;
     let testFileName = `${docs[i].name}.json`;
-    if (config.keepFileStructure && docs[i].path !== undefined && !fs.existsSync(path.join(config.outputDir, <string>docs[i].path))) {
-      await fs.promises.mkdir(path.join(config.outputDir, <string>docs[i].path), { recursive: true });
+    if (config.keepFileStructure && docs[i].path !== undefined) {
+      if (!fs.existsSync(path.join(config.outputDir, <string>docs[i].path))) await fs.promises.mkdir(path.join(config.outputDir, <string>docs[i].path), { recursive: true });
       docfileName = path.join(<string>docs[i].path, docfileName);
       testFileName = path.join(<string>docs[i].path, testFileName);
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -9,6 +9,7 @@ declare module 'hardhat/types/config' {
       testMode?: boolean;
       templatePath?: string;
       outputDir?: string;
+      keepFileStructure?: boolean;
     }
   }
 
@@ -19,7 +20,8 @@ declare module 'hardhat/types/config' {
       runOnCompile: boolean;
       testMode: boolean;
       templatePath: string;
-      outputDir: string
+      outputDir: string;
+      keepFileStructure: boolean;
     }
   }
 }


### PR DESCRIPTION
In the current version, all doc file are generated in a simple folder, and do not keep file structure of contract folder.
It could be hard to navigate through the documentation for large projects.

So I propose to add a keepFileStructure option to keep the file structure for documentation

## Implementations
- Adding a keepFileStructure option to dodoc if you want to keep the file structure in doc folder
- This option is true by default 
- Saving file path in Doc object
- Adding doc file structure logic during `fs.write`

close #15