### PR TITLE
table of contents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Here are all the configuration parameters that are currently available, but as s
 | `debugMode`          | Test mode generating additional JSON files used for debugging                                                                                              | `false`           |
 | `keepFileStructure` | True if you want to preserve your contracts file structure in the output directory                                                                                                 | `true`            |
 | `freshOutput` | True if you want to clean the output directory before generating new documentation | `true` |
+| `tableOfContents` | True if you want to generate a simple table of contents in the output directory root as `README.md` | `false` |
 
 ## 💅 Customize
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dodoc
 
-![version](https://img.shields.io/npm/v/@primitivefi/hardhat-dodoc) ![npm](https://img.shields.io/npm/dt/@primitivefi/hardhat-dodoc) ![license](https://img.shields.io/npm/l/@primitivefi/hardhat-dodoc)
+![version](https://img.shields.io/npm/v/@adradr/hardhat-dodoc) ![npm](https://img.shields.io/npm/dt/@adradr/hardhat-dodoc) ![license](https://img.shields.io/npm/l/@adradr/hardhat-dodoc)
 
 Zero-config Hardhat plugin to generate documentation for all your Solidity contracts.
 
@@ -10,7 +10,6 @@ Zero-config Hardhat plugin to generate documentation for all your Solidity contr
 - 📖 Default output to Markdown
 - 🔧 Extendable using custom templates
 
-Want to see a live example? Check out [Primitive documentation](https://docs.primitive.finance/)!
 
 ## 📦 Installation
 
@@ -18,20 +17,20 @@ First thing to do is to install the plugin in your Hardhat project:
 
 ```bash
 # Using yarn
-yarn add @primitivefi/hardhat-dodoc
+yarn add @adradr/hardhat-dodoc
 
 # Or using npm
-npm i @primitivefi/hardhat-dodoc
+npm i @adradr/hardhat-dodoc
 ```
 
 Next step is simply to include the plugin into your `hardhat.config.js` or `hardhat.config.ts` file:
 
 ```typescript
 // Using JavaScript
-require('@primitivefi/hardhat-dodoc');
+require('@adradr/hardhat-dodoc');
 
 // Using ES6 or TypeScript
-import '@primitivefi/hardhat-dodoc';
+import '@adradr/hardhat-dodoc';
 ```
 
 And you're done! Documentation will be automatically generated on the next compilation and saved into the `docs` folder at the root of your project.
@@ -138,3 +137,6 @@ Feel free to open an issue if you need help or if you encounter a problem! Here 
 - State variables overriding functions defined by an interface might "erase" the name of the parameters. A current workaround is to name the function parameters using the `_0`, `_1`, ... format.
 - Special functions such as `constructor`, `fallback` and `receive` might not be rendered.
 - Custom NatSpec tags `@custom:...` are not rendered (yet).
+
+## Credits
+The repo originally is written by @primitivefi and forked by @adradr to extend its functionality, since the original repo seems to be abandoned.

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+### Table of contents
+
+
+* [Bar](Bar.md)
+* [IBar](IBar.md)
+* [Foo](Foo.md)
+* [IFoo](IFoo.md)
+* [IExampleContract](IExampleContract.md)
+* [AnotherContract](subfolder/AnotherContract.md)

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,6 +13,7 @@ const config: HardhatUserConfig = {
     outputDir: './examples/docs',
     exclude: ['excluded'],
     runOnCompile: true,
+    tableOfContents: true,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "Zero-config Hardhat plugin to generate documentation for all your Solidity contracts",
   "repository": "github:adradr/hardhat-dodoc",
-  "author": "Primitive",
+  "author": "adradr, Primitive",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@primitivefi/hardhat-dodoc",
-  "version": "0.2.3",
+  "name": "@adradr/hardhat-dodoc",
+  "version": "0.3.0",
   "description": "Zero-config Hardhat plugin to generate documentation for all your Solidity contracts",
-  "repository": "github:primitivefinance/primitive-dodoc",
+  "repository": "github:adradr/hardhat-dodoc",
   "author": "Primitive",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     templatePath: userConfig.dodoc?.templatePath || path.join(__dirname, './template.sqrl'),
     keepFileStructure: userConfig.dodoc?.keepFileStructure ?? true,
     freshOutput: userConfig.dodoc?.freshOutput ?? true,
+    tableOfContents: userConfig.dodoc?.tableOfContents ?? false,
   };
 });
 
@@ -181,6 +182,7 @@ async function generateDocumentation(
       docfileName = path.join(<string>docs[i].path, docfileName);
       testFileName = path.join(<string>docs[i].path, testFileName);
     }
+
     await fs.promises.writeFile(
       path.join(config.outputDir, docfileName),
       result, {
@@ -196,6 +198,23 @@ async function generateDocumentation(
         },
       );
     }
+  }
+
+  if (config.tableOfContents) {
+    // Create array for table of contents
+    const tocArray = ['# Documentation\n\n### Table of contents\n\n'];
+    // Iterate over all docs
+    docs.forEach((doc) => {
+      const docfileName = `${doc.name}.md`;
+      tocArray.push(`* [${doc.name}](${config.keepFileStructure ? path.join(doc.path || '', docfileName) : docfileName})`);
+    });
+    // Write the table of contents to the output directory
+    await fs.promises.writeFile(
+      path.join(config.outputDir, 'README.md'),
+      tocArray.join('\n'), {
+        encoding: 'utf-8',
+      },
+    );
   }
 
   console.log('✅ Generated documentation for', docs.length, docs.length > 1 ? 'contracts' : 'contract');

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -11,6 +11,7 @@ declare module 'hardhat/types/config' {
       outputDir?: string;
       keepFileStructure?: boolean;
       freshOutput?: boolean;
+      tableOfContents?: boolean;
     }
   }
 
@@ -24,6 +25,7 @@ declare module 'hardhat/types/config' {
       outputDir: string;
       keepFileStructure: boolean;
       freshOutput: boolean;
+      tableOfContents: boolean;
     }
   }
 }


### PR DESCRIPTION
Simple functionality to support table of contents creation as `README.md` in output root.