### PR TITLE
Add support for custom tags

### DIFF
--- a/examples/contracts/Bar.sol
+++ b/examples/contracts/Bar.sol
@@ -35,6 +35,7 @@ interface IBar {
 /// @author  Primitive
 /// @notice  Manages the bar
 /// @dev     Blablou
+/// @custom:version v2.0.1
 contract Bar is IBar {
     /// @inheritdoc IBar
     function set(T memory t) external { }

--- a/examples/contracts/Bar.sol
+++ b/examples/contracts/Bar.sol
@@ -40,7 +40,8 @@ contract Bar is IBar {
     function set(T memory t) external { }
 
     /// @notice Cool function bro
-    /// @custom:requirement Check this requirement
+    /// @custom:requirement Check first requirement
+    /// @custom:requirement Check second requirement
     function boop(uint256 bar) external { }
 
     /// @notice Alt cool function bro

--- a/examples/contracts/Bar.sol
+++ b/examples/contracts/Bar.sol
@@ -21,11 +21,13 @@ interface IBar {
     /// @notice Emitted when transfer
     /// @dev Transfer some stuff
     /// @param foo Amount of stuff
+    /// @custom:danger This event exposes private info
     event Transfer(uint256 foo);
 
     /// @notice Thrown when doh
     /// @dev Bad doh error
     /// @param yay A bool
+    /// @custom:info Additional info
     error Doh(bool yay);
 }
 
@@ -38,6 +40,7 @@ contract Bar is IBar {
     function set(T memory t) external { }
 
     /// @notice Cool function bro
+    /// @custom:requirement Check this requirement
     function boop(uint256 bar) external { }
 
     /// @notice Alt cool function bro

--- a/examples/docs/Bar.json
+++ b/examples/docs/Bar.json
@@ -84,5 +84,6 @@
     "notice": "Manages the bar",
     "details": "Blablou",
     "author": "Primitive",
+    "custom:version": "v2.0.1",
     "name": "Bar"
 }

--- a/examples/docs/Bar.json
+++ b/examples/docs/Bar.json
@@ -25,7 +25,8 @@
                 }
             },
             "outputs": {},
-            "notice": "Cool function bro"
+            "notice": "Cool function bro",
+            "custom:requirement": "Check first requirementCheck second requirement"
         },
         "boop(uint256,uint256)": {
             "stateMutability": "nonpayable",

--- a/examples/docs/Bar.json
+++ b/examples/docs/Bar.json
@@ -74,7 +74,8 @@
                 }
             },
             "notice": "Thrown when doh",
-            "details": "Bad doh error"
+            "details": "Bad doh error",
+            "custom:info": "Additional info"
         }
     },
     "path": "",

--- a/examples/docs/Bar.md
+++ b/examples/docs/Bar.md
@@ -37,7 +37,7 @@ function boop(uint256 bar) external nonpayable
 
 Cool function bro
 
-
+**Requirement:** *Check first requirementCheck second requirement*
 
 
 

--- a/examples/docs/Bar.md
+++ b/examples/docs/Bar.md
@@ -8,6 +8,8 @@ Manages the bar
 
 *Blablou*
 
+**Version:** *v2.0.1*
+
 ## Methods
 
 ### baap

--- a/examples/docs/Bar.md
+++ b/examples/docs/Bar.md
@@ -20,6 +20,8 @@ Baaps the yaps
 
 
 
+
+
 #### Parameters
 
 | Name | Type | Description |
@@ -34,6 +36,8 @@ function boop(uint256 bar) external nonpayable
 ```
 
 Cool function bro
+
+
 
 
 
@@ -53,6 +57,8 @@ Alt cool function bro
 
 
 
+
+
 #### Parameters
 
 | Name | Type | Description |
@@ -65,6 +71,8 @@ Alt cool function bro
 ```solidity
 function set(IBar.T t) external nonpayable
 ```
+
+
 
 
 
@@ -90,6 +98,8 @@ Emitted when transfer
 
 
 
+
+
 #### Parameters
 
 | Name | Type | Description |
@@ -107,8 +117,10 @@ error Doh(bool yay)
 ```
 
 Thrown when doh
-
 *Bad doh error*
+
+
+**Info:** *Additional info*
 
 #### Parameters
 

--- a/examples/docs/Foo.md
+++ b/examples/docs/Foo.md
@@ -17,8 +17,10 @@ function nonces(address) external view returns (uint256)
 ```
 
 Returns the nonce of an address
-
 *Nonces much*
+
+
+
 
 #### Parameters
 

--- a/examples/docs/Foo.md
+++ b/examples/docs/Foo.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 ## Methods
 
 ### nonces

--- a/examples/docs/IBar.json
+++ b/examples/docs/IBar.json
@@ -45,7 +45,8 @@
                 }
             },
             "notice": "Thrown when doh",
-            "details": "Bad doh error"
+            "details": "Bad doh error",
+            "custom:info": "Additional info"
         }
     },
     "path": "",

--- a/examples/docs/IBar.json
+++ b/examples/docs/IBar.json
@@ -32,7 +32,8 @@
                 }
             },
             "notice": "Emitted when transfer",
-            "details": "Transfer some stuff"
+            "details": "Transfer some stuff",
+            "custom:danger": "This event exposes private info"
         }
     },
     "errors": {

--- a/examples/docs/IBar.md
+++ b/examples/docs/IBar.md
@@ -20,6 +20,8 @@ function boop(uint256 bar) external nonpayable
 
 
 
+
+
 #### Parameters
 
 | Name | Type | Description |
@@ -31,6 +33,8 @@ function boop(uint256 bar) external nonpayable
 ```solidity
 function set(IBar.T t) external nonpayable
 ```
+
+
 
 
 
@@ -53,8 +57,10 @@ event Transfer(uint256 foo)
 ```
 
 Emitted when transfer
-
 *Transfer some stuff*
+
+
+
 
 #### Parameters
 
@@ -73,8 +79,10 @@ error Doh(bool yay)
 ```
 
 Thrown when doh
-
 *Bad doh error*
+
+
+**Info:** *Additional info*
 
 #### Parameters
 

--- a/examples/docs/IBar.md
+++ b/examples/docs/IBar.md
@@ -59,7 +59,7 @@ event Transfer(uint256 foo)
 Emitted when transfer
 *Transfer some stuff*
 
-
+**Danger:** *This event exposes private info*
 
 
 #### Parameters

--- a/examples/docs/IBar.md
+++ b/examples/docs/IBar.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 ## Methods
 
 ### boop

--- a/examples/docs/IExampleContract.md
+++ b/examples/docs/IExampleContract.md
@@ -17,8 +17,10 @@ function anotherThing(uint256 num) external pure returns (uint256)
 ```
 
 Does another thing when the function is called.
-
 *More info about doing another thing when the function is called.*
+
+
+
 
 #### Parameters
 
@@ -43,6 +45,8 @@ Poorly documented function starting with weird spaces.
 
 
 
+
+
 #### Returns
 
 | Name | Type | Description |
@@ -56,8 +60,10 @@ function doSomething(address a, uint256 b) external nonpayable returns (uint256 
 ```
 
 Does something when this function is called.
-
 *More info about the doSomething, and this even works when the explanation is on two lines.*
+
+
+
 
 #### Parameters
 
@@ -86,6 +92,8 @@ A bad documented payable function.
 
 
 
+
+
 ## Events
 
 ### DoSomething
@@ -95,8 +103,10 @@ event DoSomething(address indexed a, uint256 b)
 ```
 
 Emitted when the function doSomething is called.
-
 *More info about the event can be added here.*
+
+
+
 
 #### Parameters
 
@@ -116,8 +126,10 @@ error RandomError(address expected, address actual)
 ```
 
 Thrown when an error happens.
-
 *More info about the error.*
+
+
+
 
 #### Parameters
 

--- a/examples/docs/IExampleContract.md
+++ b/examples/docs/IExampleContract.md
@@ -8,6 +8,8 @@ Put a simple description of the contract here.
 
 *And then a more complicated and tech oriented description of the contract there.*
 
+
+
 ## Methods
 
 ### anotherThing

--- a/examples/docs/IFoo.md
+++ b/examples/docs/IFoo.md
@@ -17,8 +17,10 @@ function nonces(address _0) external view returns (uint256)
 ```
 
 Returns the nonce of an address
-
 *Nonces much*
+
+
+
 
 #### Parameters
 

--- a/examples/docs/IFoo.md
+++ b/examples/docs/IFoo.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 ## Methods
 
 ### nonces

--- a/examples/docs/subfolder/AnotherContract.md
+++ b/examples/docs/subfolder/AnotherContract.md
@@ -17,8 +17,10 @@ function tip(uint256 much, address mop) external nonpayable
 ```
 
 A strange function
-
 *Someone wrote this weird function...*
+
+
+
 
 #### Parameters
 

--- a/examples/docs/subfolder/AnotherContract.md
+++ b/examples/docs/subfolder/AnotherContract.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 ## Methods
 
 ### tip

--- a/src/dodocTypes.ts
+++ b/src/dodocTypes.ts
@@ -1,147 +1,156 @@
-import { CompilerOutputContract } from 'hardhat/types';
+import { CompilerOutputContract } from "hardhat/types";
+
+export type CustomTag<T extends string> = `custom:${T}`;
 
 export interface ErrorDevdocArrayItem {
-  details?: string;
-  params?: {
-    [key: string]: string;
-  }
+    details?: string;
+    params?: {
+        [key: string]: string;
+    };
+    [key: CustomTag<string>]: string
 }
 
 declare interface ErrorUserdocArrayItem {
-  notice?: string;
+    notice?: string;
 }
 
 export interface CompilerOutputContractWithDocumentation extends CompilerOutputContract {
-  devdoc?: {
-    author?: string;
-    details?: string;
-    title?: string;
-    errors?: {
-      [key: string]: ErrorDevdocArrayItem[]
-    }
-    events?: {
-      [key: string]: {
-        details: string;
-        params: {
-          [key: string]: string;
-        }
-      }
-    }
-    methods?: {
-      [key: string]: {
+    devdoc?: {
+        author?: string;
         details?: string;
-        params: {
-          [key: string]: string;
-        },
-        returns: {
-          [key: string]: string;
-        }
-      }
-    },
-    returns?: {
-      [key: string]: {
-        details?: string;
-        params: {
-          [key: string]: string;
-        }
-      }
-    }
-    stateVariables?: {
-      [key: string]: {
-        details?: string;
-        params: {
-          [key: string]: string;
-        }
-        returns: {
-          [key: string]: string;
-        }
-      }
-    }
-  },
-  userdoc?: {
-    errors?: {
-      [key: string]: ErrorUserdocArrayItem[]
-    },
-    events?: {
-      [key: string]: {
-        notice: string;
-      },
-    },
-    methods?: {
-      [key: string]: {
-        notice: string;
-      },
-    },
-    notice?: string;
-  }
+        title?: string;
+        errors?: {
+            [key: string]: ErrorDevdocArrayItem[];
+        };
+        events?: {
+            [key: string]: {
+                details: string;
+                params: {
+                    [key: string]: string;
+                };
+                [key: CustomTag<string>]: string
+            };
+        };
+        methods?: {
+            [key: string]: {
+                details?: string;
+                params: {
+                    [key: string]: string;
+                };
+                returns: {
+                    [key: string]: string;
+                };
+                [key: CustomTag<string>]: string
+            };
+        };
+        returns?: {
+            [key: string]: {
+                details?: string;
+                params: {
+                    [key: string]: string;
+                };
+            };
+        };
+        stateVariables?: {
+            [key: string]: {
+                details?: string;
+                params: {
+                    [key: string]: string;
+                };
+                returns: {
+                    [key: string]: string;
+                };
+            };
+        };
+        [key: CustomTag<string>]: string
+    };
+    userdoc?: {
+        errors?: {
+            [key: string]: ErrorUserdocArrayItem[];
+        };
+        events?: {
+            [key: string]: {
+                notice: string;
+            };
+        };
+        methods?: {
+            [key: string]: {
+                notice: string;
+            };
+        };
+        notice?: string;
+    };
 }
 
 export interface AbiElementPut {
-  internalType: string;
-  name: string;
-  type: string;
-  indexed?: boolean;
+    internalType: string;
+    name: string;
+    type: string;
+    indexed?: boolean;
 }
 
 export interface AbiElement {
-  type: 'constructor' | 'function' | 'event' | 'error';
-  name: string;
-  stateMutability?: string;
-  inputs: AbiElementPut[];
-  outputs: AbiElementPut[];
+    type: 'constructor' | 'function' | 'event' | 'error';
+    name: string;
+    stateMutability?: string;
+    inputs: AbiElementPut[];
+    outputs: AbiElementPut[];
 }
 
 export interface Param {
-  type?: string;
-  description?: string;
-  indexed?: boolean;
+    type?: string;
+    description?: string;
+    indexed?: boolean;
 }
 
 export interface Method {
-  code?: string;
-  stateMutability?: string;
-  notice?: string;
-  details?: string;
-  inputs: {
-    [key: string]: Param;
-  }
-  outputs: {
-    [key: string]: Param;
-  }
+    code?: string;
+    stateMutability?: string;
+    notice?: string;
+    details?: string;
+    inputs: {
+        [key: string]: Param;
+    };
+    outputs: {
+        [key: string]: Param;
+    };
+    [key: CustomTag<string>]: string
 }
 
 export interface Event {
-  code?: string;
-  notice?: string;
-  details?: string;
-  inputs: {
-    [key: string]: Param;
-  }
+    code?: string;
+    notice?: string;
+    details?: string;
+    inputs: {
+        [key: string]: Param;
+    };
+    [key: CustomTag<string>]: string
 }
 
 export interface Error {
-  code?: string;
-  description?: string;
-  details?: string;
-  inputs: {
-    [key: string]: Param;
-  }
+    code?: string;
+    notice?: string;
+    details?: string;
+    inputs: {
+        [key: string]: Param;
+    };
+    [key: CustomTag<string>]: string
 }
 
 export interface Doc {
-  path?: string;
-  name?: string;
-  title?: string;
-  notice?: string;
-  details?: string;
-  author?: string;
-  methods: {
-    [key: string]: Method;
-  }
-  events: {
-    [key: string]: Event;
-  }
-  errors: {
-    [key: string]: Event;
-  }
+    path?: string;
+    name?: string;
+    title?: string;
+    notice?: string;
+    details?: string;
+    author?: string;
+    methods: {
+        [key: string]: Method;
+    };
+    events: {
+        [key: string]: Event;
+    };
+    errors: {
+        [key: string]: Error;
+    };
 }

--- a/src/dodocTypes.ts
+++ b/src/dodocTypes.ts
@@ -62,7 +62,7 @@ export interface CompilerOutputContractWithDocumentation extends CompilerOutputC
                 };
             };
         };
-        [key: CustomTag<string>]: string
+        [key: CustomTag<string>]: string;
     };
     userdoc?: {
         errors?: {
@@ -144,6 +144,7 @@ export interface Doc {
     notice?: string;
     details?: string;
     author?: string;
+    [key: CustomTag<string>]: string;
     methods: {
         [key: string]: Method;
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function generateDocumentation(
 
       for (const value in event) {
         if (value.startsWith('custom:')) {
-          const strippedValue = value.substring(6);
+          const strippedValue = value.substring(7);
           if (strippedValue.length > 0) {
             doc.events[eventName][`custom:${strippedValue}`] = event[`custom:${strippedValue}`];
           }
@@ -145,7 +145,7 @@ async function generateDocumentation(
 
       for (const value in method) {
         if (value.startsWith('custom:')) {
-          const strippedValue = value.substring(6);
+          const strippedValue = value.substring(7);
           if (strippedValue.length > 0) {
             doc.methods[methodSig][`custom:${strippedValue}`] = method[`custom:${strippedValue}`];
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,15 @@ async function generateDocumentation(
       for (const param in error?.params) {
         if (doc.errors[errorName].inputs[param]) doc.errors[errorName].inputs[param].description = error?.params[param];
       }
+
+      for (const value in error) {
+        if (value.startsWith('custom:')) {
+          const strippedValue = value.substring(7);
+          if (strippedValue.length > 0) {
+            doc.errors[errorName][`custom:${strippedValue}`] = error[`custom:${strippedValue}`];
+          }
+        }
+      }
     }
 
     for (const eventSig in info.devdoc?.events) {
@@ -106,6 +115,15 @@ async function generateDocumentation(
 
       for (const param in event?.params) {
         if (doc.events[eventName].inputs[param]) doc.events[eventName].inputs[param].description = event?.params[param];
+      }
+
+      for (const value in event) {
+        if (value.startsWith('custom:')) {
+          const strippedValue = value.substring(6);
+          if (strippedValue.length > 0) {
+            doc.events[eventName][`custom:${strippedValue}`] = event[`custom:${strippedValue}`];
+          }
+        }
       }
     }
 
@@ -122,6 +140,15 @@ async function generateDocumentation(
 
         for (const output in method?.returns) {
           if (doc.methods[methodSig].outputs[output]) doc.methods[methodSig].outputs[output].description = method?.returns[output];
+        }
+      }
+
+      for (const value in method) {
+        if (value.startsWith('custom:')) {
+          const strippedValue = value.substring(6);
+          if (strippedValue.length > 0) {
+            doc.methods[methodSig][`custom:${strippedValue}`] = method[`custom:${strippedValue}`];
+          }
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ async function generateDocumentation(
       console.log(JSON.stringify(info.devdoc, null, 4));
     }
 
-    const doc = { ...decodeAbi(info.abi), path: source.substr(sourcesPath.length).split('/').slice(0, -1).join('/') }; // get file path without filename
+    const doc: Doc = { ...decodeAbi(info.abi), path: source.substr(sourcesPath.length).split('/').slice(0, -1).join('/') }; // get file path without filename
 
     // Fetches info from userdoc
     for (const errorSig in info.userdoc?.errors) {
@@ -177,6 +177,15 @@ async function generateDocumentation(
     if (info.userdoc?.notice) doc.notice = info.userdoc.notice;
     if (info.devdoc?.details) doc.details = info.devdoc.details;
     if (info.devdoc?.author) doc.author = info.devdoc.author;
+
+    for (const value in info.devdoc) {
+      if (value.startsWith('custom:')) {
+        const strippedValue = value.substring(7);
+        if (strippedValue.length > 0) {
+          doc[`custom:${strippedValue}`] = info.devdoc[`custom:${strippedValue}`];
+        }
+      }
+    }
 
     doc.name = name;
     docs.push(doc);

--- a/src/template.sqrl
+++ b/src/template.sqrl
@@ -13,6 +13,9 @@
 {{@if (it.details)}}*{{it.details}}*{{/if}}
 
 
+{{@if (it['custom:version'])}}**Version:** *{{it['custom:version']}}*{{/if}}
+
+
 {{@if (Object.keys(it.methods).length > 0)}}
 ## Methods
 

--- a/src/template.sqrl
+++ b/src/template.sqrl
@@ -27,8 +27,13 @@
 
 {{@if (val.notice)}}{{val.notice}}{{/if}}
 
-
 {{@if (val.details)}}*{{val.details}}*{{/if}}
+
+{{@if (val['custom:requirement'])}}**Requirement:** *{{val['custom:requirement']}}*{{/if}}
+
+{{@if (val['custom:danger'])}}**Danger:** *{{val['custom:danger']}}*{{/if}}
+
+{{@if (val['custom:info'])}}**Info:** *{{val['custom:info']}}*{{/if}}
 
 
 {{@if (Object.keys(val.inputs).length > 0)}}
@@ -69,8 +74,13 @@
 
 {{@if (val.notice)}}{{val.notice}}{{/if}}
 
-
 {{@if (val.details)}}*{{val.details}}*{{/if}}
+
+{{@if (val['custom:requirement'])}}**Requirement:** *{{val['custom:requirement']}}*{{/if}}
+
+{{@if (val['custom:danger'])}}**Danger:** *{{val['custom:danger']}}*{{/if}}
+
+{{@if (val['custom:info'])}}**Info:** *{{val['custom:info']}}*{{/if}}
 
 
 {{@if (Object.keys(val.inputs).length > 0)}}
@@ -101,8 +111,13 @@
 
 {{@if (val.notice)}}{{val.notice}}{{/if}}
 
-
 {{@if (val.details)}}*{{val.details}}*{{/if}}
+
+{{@if (val['custom:requirement'])}}**Requirement:** *{{val['custom:requirement']}}*{{/if}}
+
+{{@if (val['custom:danger'])}}**Danger:** *{{val['custom:danger']}}*{{/if}}
+
+{{@if (val['custom:info'])}}**Info:** *{{val['custom:info']}}*{{/if}}
 
 
 {{@if (Object.keys(val.inputs).length > 0)}}


### PR DESCRIPTION
### What does this PR introduce?

Feature related to Issue #29 

Allows for `@custom:..` tags discovery and use in the process of generating the markdown file.